### PR TITLE
Update 00-getting-started.ipynb

### DIFF
--- a/samples/notebooks/python/00-getting-started.ipynb
+++ b/samples/notebooks/python/00-getting-started.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "api_key, org_id = sk.openai_settings_from_dot_env()\n",
     "\n",
-    "kernel.add_text_completion_service(\"dv\", OpenAITextCompletion(\"text-davinci-003\", api_key, org_id))"
+    "kernel.add_text_completion_service(\"dv\", OpenAITextCompletion(\"gpt-3.5-turbo\", api_key, org_id))"
    ]
   },
   {


### PR DESCRIPTION

  1. Kernel examples and notebooks still use text-davinci-003, which is being retired by Azure OpenAI and is no longer supported 
  for new deployments.
  2. e should update these to use a more current model such as gpt-35-turbo.
  3. If it fixes an open issue,#2309
